### PR TITLE
fix segfault bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Route Annotator releases
+
+## 0.0.4
+ - Fixed bug of segfaulting if using the hashmap without loading CSVs first
+
+## 0.0.3
+ - Added SpeedLookup() to read CSV files and load a hashmap of NodeId pairs (key) and speeds (value)
+ - Changed over build system to use mason
+
+## 0.0.2
+ - Added Annotator() for looking up OSM tag data from OSM node IDs or coordinates
+
+## 0.0.1
+ - First versioned release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route_annotator",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Bindings for route-annotator",
   "keywords": [
     "addon",

--- a/src/segment_speed_map.cpp
+++ b/src/segment_speed_map.cpp
@@ -80,7 +80,7 @@ SegmentSpeedMap::getValues(const std::vector<external_nodeid_t> &route) const
     if (route.size() < 2)
     {
         throw std::runtime_error(
-            "NodeID Array should have more than 2 NodeIds for getValues methodr.");
+            "NodeID Array should have more than 2 NodeIds for getValues method.");
     }
 
     speeds.resize(route.size() - 1);

--- a/src/speed_lookup_bindings.cpp
+++ b/src/speed_lookup_bindings.cpp
@@ -1,4 +1,6 @@
 #include "speed_lookup_bindings.hpp"
+#include "types.hpp"
+#include <algorithm>
 #include <vector>
 
 NAN_MODULE_INIT(SpeedLookup::Init)
@@ -177,7 +179,20 @@ NAN_METHOD(SpeedLookup::getRouteSpeeds)
             : Base(callback), datamap{datamap_}, nodeIds(std::move(nodeIds))
         {
         }
-        void Execute() override { result_annotations = datamap->getValues(nodeIds); }
+
+        void Execute() override
+        {
+            if (datamap)
+            {
+                result_annotations = datamap->getValues(nodeIds);
+            }
+            else
+            {
+                result_annotations.resize(nodeIds.size() - 1);
+                std::fill(result_annotations.begin(), result_annotations.end(), INVALID_SPEED);
+            }
+        }
+
         void HandleOKCallback() override
         {
             Nan::HandleScope scope;

--- a/test/load.test.js
+++ b/test/load.test.js
@@ -2,7 +2,7 @@ var test = require('tape');
 const bindings = require('../index');
 const annotator = new bindings.Annotator();
 const segmentmap = new bindings.SpeedLookup();
-var path = require('path');
+const path = require('path');
 
 test('load extract', function(t) {
   annotator.loadOSMExtract(path.join(__dirname,'data/winthrop.osm'), (err) => {
@@ -48,6 +48,7 @@ test('initialization failure with parameters', function(t) {
   t.throws(function() { var foo = new bindings.SpeedLookup("test"); }, /No types expected/, "Check that lookup can't be constructed with parameters");
   t.end();
 });
+
 
 test('check CSV loading', function(t) {
   t.throws(function(cb) { 
@@ -106,6 +107,24 @@ test('lookup node pair from second file', function(t) {
   segmentmap.getRouteSpeeds([90,91,92,93], (err, resp)=> {
     if (err) { console.log(err); throw err; }
     t.same(resp, [2,3,4], "Verify expected speed results");
+    t.end();
+  });
+});
+
+test('make sure that it works even if CSV is not loaded', function(t) {
+  var speedlookup = new bindings.SpeedLookup();
+  speedlookup.getRouteSpeeds([90,91,92,93], (err, resp)=> {
+    if (err) { console.log(err); throw err; }
+    t.ok(resp, "Return results even if CSV is not loaded");
+    t.end();
+  });
+});
+
+test('dont load CSV and see if you get the correct response (4 INVALID_SPEEDs)', function(t) {
+  var speedlookup = new bindings.SpeedLookup();
+  speedlookup.getRouteSpeeds([90,91,92,93], (err, resp)=> {
+    if (err) { console.log(err); throw err; }
+    t.same(resp, [ 4294967295, 4294967295, 4294967295 ], "Verify expected speed results");
     t.end();
   });
 });


### PR DESCRIPTION
# Issue
Addresses Issue: https://github.com/mapbox/route-annotator/issues/12

# Description
Problem: When the hashmap is accessed without first loading the CSV, SpeedLookup() segfaults. This happens in the node bindings, because the hashmap pointer points to NULL: https://github.com/mapbox/route-annotator/blob/master/src/speed_lookup_bindings.cpp#L180

Fix: This PR adds a check to see whether the hashmap is initialized. If it is not initialized (and the CSV hasn't been loaded) it returns an array with the correct number of INVALID_SPEED values: https://github.com/mapbox/route-annotator/pull/13/files#diff-e1639d46926aed3e53868ed44667dca1R184

# Steps
- [x] Write failing tests according to https://github.com/mapbox/route-annotator/issues/12
- [x] Make tests pass
- [x] Review
- [ ] Merge PR to master
- [ ] Tag the release
- [ ] Publish binaries by pushing an empty commit with the words [publish binary] in the commit message (I use git commit --allow-empty -m '[publish binary]' && git push).
- [ ] npm publish new version to the npmjs.org repository
