### PR TITLE
added npmignore and got rid of massive unecessary fixture

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,13 @@
+/build
+lib/binding
+node_modules
+npm-debug.log
+/mason
+/mason_packages
+nodes.cache
+*profraw
+*profdata
+.mason
+.toolchain
+local.env
+/test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Route Annotator releases
 
+## 0.0.5
+ - Removed large unecessary test fixture from published npm module
+
 ## 0.0.4
  - Fixed bug of segfaulting if using the hashmap without loading CSVs first
 

--- a/README.md
+++ b/README.md
@@ -123,3 +123,13 @@ Then, in a new terminal, you should be able to do:
 ```
 curl "http://localhost:5000/coordlist/7.422155,43.7368838;7.4230139,43.7369751"
 ```
+
+#### Release
+
+- `git checkout master`
+- Update CHANGELOG.md
+- Bump version in package.json
+- `git commit -am "vx.y.z [publish binary]"` with Changelog list in commit message
+- `git tag vx.y.z -a` with Changelog list in tag message
+- `git push origin master; git push origin --tags`
+- `npm publish`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route_annotator",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Bindings for route-annotator",
   "keywords": [
     "addon",


### PR DESCRIPTION
We accidentally committed a really huge fixture into this repo earlier when creating the congestion-annotator lookup table. We discovered this because it kept pushing the slug size of api-directions over 100MB total when implementing [congestion-annotations](https://github.com/mapbox/api-directions/pull/993).

Removing that fixture in this PR as well as adding back an `.npmignore` that has mysteriously disappeared.

TODO:

- [ ] `git checkout master`
- [ ] Update CHANGELOG.md
- [ ] Bump version in package.json
- [ ] `git commit -am "vx.y.z [publish binary]"` with Changelog list in commit message
- [ ] `git tag vx.y.z -a` with Changelog list in tag message
- [ ] `git push origin master; git push origin --tags`
- [ ] `npm publish` 