### PR TITLE
Do not publish binary if TOOLSET is set (again)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,8 +88,6 @@ matrix:
         - export ASAN_OPTIONS=fast_unwind_on_malloc=0:${ASAN_OPTIONS}
         - npm test
         - unset LD_PRELOAD
-        # after successful tests, publish binaries if specified in commit message
-        - ./scripts/publish.sh --toolset=${TOOLSET:-} --debug=$([ "${BUILDTYPE}" == 'debug' ] && echo "true" || echo "false")
     # g++ build (default builds all use clang++)
     - os: linux
       env: BUILDTYPE=debug CXX="g++-6" CC="gcc-6"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -37,8 +37,6 @@ function publish() {
 
   if [[ $(is_pr_merge) ]]; then
       echo "Skipping publishing because this is a PR merge commit"
-  elif [[ -n "${TOOLSET:-}" ]]; then
-      echo "Skipping publishing since TOOLSET is set"
   else
       echo "Commit message: ${COMMIT_MESSAGE}"
 


### PR DESCRIPTION
Taking @springmeyer's advice from https://github.com/mapbox/route-annotator/pull/17#issuecomment-315214728.

I think it's fine to not publish ASAN binaries for now.