### PR TITLE
Make rtree construction optional

### DIFF
--- a/example-server.js
+++ b/example-server.js
@@ -74,8 +74,10 @@ function coordListHandler(annotator) {
       return res.sendStatus(400);
 
     annotator.annotateRouteFromLonLats(coordinates, (err, wayIds) => {
-      if (err)
+      if (err) {
+        console.error(err);
         return res.sendStatus(400);
+      }
 
       var response = {"way_indexes": [], "ways_seen": []};
       var way_indexes = {};

--- a/example-server.js
+++ b/example-server.js
@@ -21,7 +21,7 @@ function main() {
     next();
   });
 
-  const annotator = new bindings.Annotator();
+  const annotator = new bindings.Annotator({coordinates: true});
 
   app.get('/nodelist/:nodelist', nodeListHandler(annotator));
   app.get('/coordlist/:coordlist', coordListHandler(annotator));

--- a/example-server.js
+++ b/example-server.js
@@ -21,7 +21,7 @@ function main() {
     next();
   });
 
-  const annotator = new bindings.Annotator({coordinates: true});
+  const annotator = new bindings.Annotator();
 
   app.get('/nodelist/:nodelist', nodeListHandler(annotator));
   app.get('/coordlist/:coordlist', coordListHandler(annotator));

--- a/src/annotator.cpp
+++ b/src/annotator.cpp
@@ -20,8 +20,7 @@ RouteAnnotator::coordinates_to_internal(const std::vector<point_t> &points)
     static const double MAX_DISTANCE = 5;
 
     if (!db.rtree)
-        throw std::runtime_error(
-            "RTree is null - need to call build_rtree() on database before use");
+        throw RtreeError("RTree is null - call build_rtree() on database before use");
 
     std::vector<internal_nodeid_t> internal_nodeids;
     for (const auto &point : points)

--- a/src/annotator.cpp
+++ b/src/annotator.cpp
@@ -20,7 +20,7 @@ RouteAnnotator::coordinates_to_internal(const std::vector<point_t> &points)
     static const double MAX_DISTANCE = 5;
 
     if (!db.rtree)
-        throw std::runtime_error("RTree is null - need to call compact() on database before use");
+        throw std::runtime_error("RTree is null - need to call build_rtree() on database before use");
 
     std::vector<internal_nodeid_t> internal_nodeids;
     for (const auto &point : points)

--- a/src/annotator.cpp
+++ b/src/annotator.cpp
@@ -20,7 +20,8 @@ RouteAnnotator::coordinates_to_internal(const std::vector<point_t> &points)
     static const double MAX_DISTANCE = 5;
 
     if (!db.rtree)
-        throw std::runtime_error("RTree is null - need to call build_rtree() on database before use");
+        throw std::runtime_error(
+            "RTree is null - need to call build_rtree() on database before use");
 
     std::vector<internal_nodeid_t> internal_nodeids;
     for (const auto &point : points)

--- a/src/annotator.hpp
+++ b/src/annotator.hpp
@@ -76,6 +76,12 @@ struct RouteAnnotator
      */
     tagrange_t get_tag_range(const wayid_t wayid);
 
+    struct RtreeError final : std::runtime_error
+    {
+        using base = std::runtime_error;
+        using base::base;
+    };
+
   private:
     // This is where all the data lives
     const Database &db;

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -8,13 +8,16 @@ Database::Database(bool _createRTree) : createRTree(_createRTree)
 {
 }
 
-void Database::compact()
+void Database::build_rtree()
 {
     rtree = createRTree ?
         std::make_unique<boost::geometry::index::rtree<value_t, boost::geometry::index::rstar<8>>>(
             used_nodes_list.begin(), used_nodes_list.end())
         : nullptr;
+}
 
+void Database::compact()
+{
     // Tricks to free memory, swap out data with empty versions
     // This frees the memory.  shrink_to_fit doesn't guarantee that.
     std::vector<value_t>().swap(used_nodes_list);

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -2,7 +2,6 @@
 
 Database::Database()
 {
-    createRTree = false;
 }
 Database::Database(bool _createRTree) : createRTree(_createRTree)
 {

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -1,18 +1,15 @@
 #include "database.hpp"
 
-Database::Database()
-{
-}
-Database::Database(bool _createRTree) : createRTree(_createRTree)
-{
-}
+Database::Database() {}
+Database::Database(bool _createRTree) : createRTree(_createRTree) {}
 
 void Database::build_rtree()
 {
-    rtree = createRTree ?
-        std::make_unique<boost::geometry::index::rtree<value_t, boost::geometry::index::rstar<8>>>(
-            used_nodes_list.begin(), used_nodes_list.end())
-        : nullptr;
+    rtree = createRTree
+                ? std::make_unique<
+                      boost::geometry::index::rtree<value_t, boost::geometry::index::rstar<8>>>(
+                      used_nodes_list.begin(), used_nodes_list.end())
+                : nullptr;
 }
 
 void Database::compact()

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -1,10 +1,19 @@
 #include "database.hpp"
 
+Database::Database()
+{
+    createRTree = false;
+}
+Database::Database(bool _createRTree) : createRTree(_createRTree)
+{
+}
+
 void Database::compact()
 {
-    rtree =
+    rtree = createRTree ?
         std::make_unique<boost::geometry::index::rtree<value_t, boost::geometry::index::rstar<8>>>(
-            used_nodes_list.begin(), used_nodes_list.end());
+            used_nodes_list.begin(), used_nodes_list.end())
+        : nullptr;
 
     // Tricks to free memory, swap out data with empty versions
     // This frees the memory.  shrink_to_fit doesn't guarantee that.

--- a/src/database.hpp
+++ b/src/database.hpp
@@ -14,6 +14,10 @@ struct Database
   Database(bool _createRTree);
   public:
     /**
+     * Only create RTree if explicitly told to
+     */
+    bool createRTree;
+    /**
      * A map of internal node id pairs to the way they belong to
      * TODO: support multiple ways???
      */
@@ -60,7 +64,12 @@ struct Database
     std::string getstring(const stringid_t stringid) const;
 
     /**
-     * Builds the RTree and reclaims memory by discarding temporary data
+     * Builds the RTree. Needs to be called after
+     * all OSM data parsing has been added.
+     */
+    void build_rtree();
+    /**
+     * Reclaims memory by discarding temporary data
      * and shrinking vectors that have auto-grown.  Needs to be called after
      * all OSM data parsing has been added.
      */
@@ -82,5 +91,4 @@ struct Database
     // A temporary lookup table so that we can re-use strings
     std::unordered_map<std::string, std::uint32_t> string_index;
     // TODO pull rtree creation out of compact function
-    bool createRTree;
 };

--- a/src/database.hpp
+++ b/src/database.hpp
@@ -10,8 +10,9 @@
  */
 struct Database
 {
-  Database();
-  Database(bool _createRTree);
+    Database();
+    Database(bool _createRTree);
+
   public:
     /**
      * Only create RTree if explicitly told to

--- a/src/database.hpp
+++ b/src/database.hpp
@@ -16,7 +16,7 @@ struct Database
     /**
      * Only create RTree if explicitly told to
      */
-    bool createRTree;
+    bool createRTree = false;
     /**
      * A map of internal node id pairs to the way they belong to
      * TODO: support multiple ways???

--- a/src/database.hpp
+++ b/src/database.hpp
@@ -10,6 +10,8 @@
  */
 struct Database
 {
+  Database();
+  Database(bool _createRTree);
   public:
     /**
      * A map of internal node id pairs to the way they belong to
@@ -79,4 +81,6 @@ struct Database
     std::vector<stringoffset_t> string_offsets;
     // A temporary lookup table so that we can re-use strings
     std::unordered_map<std::string, std::uint32_t> string_index;
+    // TODO pull rtree creation out of compact function
+    bool createRTree;
 };

--- a/src/extractor.cpp
+++ b/src/extractor.cpp
@@ -50,8 +50,11 @@ Extractor::Extractor(const std::string &osmfilename, Database &db) : db(db)
     std::cerr << "Number of node pairs indexed: " << db.pair_way_map.size() << "\n";
     std::cerr << "Number of ways indexed: " << db.way_tag_ranges.size() << "\n";
 
-    // TODO split up compact() method into compacting and rtree creation
-    std::cerr << "Constructing RTree ... " << std::flush;
+    if (db.createRTree)
+    {
+        std::cerr << "Constructing RTree ... " << std::flush;
+        db.build_rtree();
+    }
     db.compact();
     std::cerr << "done\n" << std::flush;
     db.dump();
@@ -81,7 +84,11 @@ Extractor::Extractor(const char *buffer,
     std::cerr << "Number of node pairs indexed: " << db.pair_way_map.size() << "\n";
     std::cerr << "Number of ways indexed: " << db.way_tag_ranges.size() << "\n";
 
-    std::cerr << "Constructing RTree ... " << std::flush;
+    if (db.createRTree)
+    {
+        std::cerr << "Constructing RTree ... " << std::flush;
+        db.build_rtree();
+    }
     db.compact();
     std::cerr << "done\n" << std::flush;
     db.dump();

--- a/src/extractor.cpp
+++ b/src/extractor.cpp
@@ -50,6 +50,7 @@ Extractor::Extractor(const std::string &osmfilename, Database &db) : db(db)
     std::cerr << "Number of node pairs indexed: " << db.pair_way_map.size() << "\n";
     std::cerr << "Number of ways indexed: " << db.way_tag_ranges.size() << "\n";
 
+    // TODO split up compact() method into compacting and rtree creation
     std::cerr << "Constructing RTree ... " << std::flush;
     db.compact();
     std::cerr << "done\n" << std::flush;

--- a/src/nodejs_bindings.cpp
+++ b/src/nodejs_bindings.cpp
@@ -34,7 +34,8 @@ NAN_MODULE_INIT(Annotator::Init)
 NAN_METHOD(Annotator::New)
 {
     bool coordinates = false;
-    if (info.Length() != 0) {
+    if (info.Length() != 0)
+    {
         if (!info[0]->IsObject())
             return Nan::ThrowTypeError("Options should be an object");
         const auto options = info[0].As<v8::Object>();
@@ -45,7 +46,11 @@ NAN_METHOD(Annotator::New)
             if (parsedCoords->IsBoolean())
             {
                 coordinates = parsedCoords->BooleanValue();
-            } else return Nan::ThrowSyntaxError("Coordinates value should be a boolean");
+            }
+            else
+            {
+                return Nan::ThrowSyntaxError("Coordinates value should be a boolean");
+            }
         }
     }
 
@@ -260,8 +265,21 @@ NAN_METHOD(Annotator::annotateRouteFromLonLats)
 
         void Execute() override
         {
-            const auto internalIds = self.annotator->coordinates_to_internal(coordinates);
-            wayIds = self.annotator->annotateRoute(internalIds);
+            try
+            {
+                const auto internalIds = self.annotator->coordinates_to_internal(coordinates);
+                wayIds = self.annotator->annotateRoute(internalIds);
+            }
+            catch (const std::exception &e)
+            {
+                /*
+                if (std::strcmp(e.what, "RTree is null", 12))
+                {
+                    return SetErrorMessage("Annotator was not configured with coordinates support");
+                }
+                */
+                return SetErrorMessage(e.what());
+            }
         }
 
         void HandleOKCallback() override

--- a/src/nodejs_bindings.cpp
+++ b/src/nodejs_bindings.cpp
@@ -270,14 +270,13 @@ NAN_METHOD(Annotator::annotateRouteFromLonLats)
                 const auto internalIds = self.annotator->coordinates_to_internal(coordinates);
                 wayIds = self.annotator->annotateRoute(internalIds);
             }
+            catch (const RouteAnnotator::RtreeError &e)
+            {
+                std::cerr << e.what() << std::endl;
+                return SetErrorMessage("Annotator not created with coordinates support");
+            }
             catch (const std::exception &e)
             {
-                /*
-                if (std::strcmp(e.what, "RTree is null", 12))
-                {
-                    return SetErrorMessage("Annotator was not configured with coordinates support");
-                }
-                */
                 return SetErrorMessage(e.what());
             }
         }

--- a/src/nodejs_bindings.cpp
+++ b/src/nodejs_bindings.cpp
@@ -45,7 +45,7 @@ NAN_METHOD(Annotator::New)
             if (parsedCoords->IsBoolean())
             {
                 coordinates = parsedCoords->BooleanValue();
-            } else return Nan::ThrowTypeError("Coordinates value should be a boolean"); // todo check what kind of error to throw
+            } else return Nan::ThrowSyntaxError("Coordinates value should be a boolean");
         }
     }
 

--- a/src/nodejs_bindings.cpp
+++ b/src/nodejs_bindings.cpp
@@ -33,12 +33,26 @@ NAN_MODULE_INIT(Annotator::Init)
 
 NAN_METHOD(Annotator::New)
 {
-    if (info.Length() != 0)
-        return Nan::ThrowTypeError("No types expected");
+    bool coordinates = false;
+    if (info.Length() != 0) {
+        if (!info[0]->IsObject())
+            return Nan::ThrowTypeError("Options should be an object");
+        const auto options = info[0].As<v8::Object>();
+        auto tryParseCoordinates = Nan::Get(options, Nan::New("coordinates").ToLocalChecked());
+        if (!tryParseCoordinates.IsEmpty())
+        {
+            auto parsedCoords = tryParseCoordinates.ToLocalChecked();
+            if (parsedCoords->IsBoolean())
+            {
+                coordinates = parsedCoords->BooleanValue();
+            } else return Nan::ThrowTypeError("Coordinates value should be a boolean"); // todo check what kind of error to throw
+        }
+    }
 
     if (info.IsConstructCall())
     {
         auto *const self = new Annotator;
+        self->createRTree = coordinates;
         self->Wrap(info.This());
         info.GetReturnValue().Set(info.This());
     }
@@ -57,6 +71,7 @@ NAN_METHOD(Annotator::loadOSMExtract)
     if (info.Length() != 2 || !info[0]->IsString() || !info[1]->IsFunction())
         return Nan::ThrowTypeError("String and callback expected");
 
+    // Validate function parameters, file path and callback
     const Nan::Utf8String utf8String(info[0]);
 
     if (!(*utf8String))
@@ -76,7 +91,7 @@ NAN_METHOD(Annotator::loadOSMExtract)
             try
             {
                 // Note: provide strong exception safety guarantee (rollback)
-                auto database = std::make_unique<Database>();
+                auto database = std::make_unique<Database>(self.createRTree);
                 Extractor extractor{path, *database};
                 auto annotator = std::make_unique<RouteAnnotator>(*database);
 

--- a/src/nodejs_bindings.cpp
+++ b/src/nodejs_bindings.cpp
@@ -49,8 +49,14 @@ NAN_METHOD(Annotator::New)
             }
             else
             {
-                return Nan::ThrowSyntaxError("Coordinates value should be a boolean");
+                return Nan::ThrowTypeError("Coordinates value should be a boolean");
             }
+        }
+        else
+        {
+            // options object isn't empty, and it doesn't have a 'coordinates' option
+            // we don't accept any other options right now
+            return Nan::ThrowError("Unrecognized annotator options");
         }
     }
 
@@ -272,7 +278,6 @@ NAN_METHOD(Annotator::annotateRouteFromLonLats)
             }
             catch (const RouteAnnotator::RtreeError &e)
             {
-                std::cerr << e.what() << std::endl;
                 return SetErrorMessage("Annotator not created with coordinates support");
             }
             catch (const std::exception &e)

--- a/src/nodejs_bindings.hpp
+++ b/src/nodejs_bindings.hpp
@@ -34,7 +34,7 @@ class Annotator final : public Nan::ObjectWrap
     static Nan::Persistent<v8::Function> &constructor();
 
     /* Wrapping Annotator; both database and annotator do not provide default ctor: wrap in ptr */
-    bool createRTree;
+    bool createRTree = false;
     std::unique_ptr<Database> database;
     std::unique_ptr<RouteAnnotator> annotator;
 };

--- a/src/nodejs_bindings.hpp
+++ b/src/nodejs_bindings.hpp
@@ -34,6 +34,7 @@ class Annotator final : public Nan::ObjectWrap
     static Nan::Persistent<v8::Function> &constructor();
 
     /* Wrapping Annotator; both database and annotator do not provide default ctor: wrap in ptr */
+    bool createRTree;
     std::unique_ptr<Database> database;
     std::unique_ptr<RouteAnnotator> annotator;
 };

--- a/test/basic/database.cpp
+++ b/test/basic/database.cpp
@@ -20,6 +20,10 @@ BOOST_AUTO_TEST_CASE(database_string_test)
     BOOST_CHECK_EQUAL(db.getstring(id), "test");
     BOOST_CHECK_EQUAL(id, 0);
 
+    Database db_with_rtree(true);
+    db_with_rtree.compact();
+    db_with_rtree.build_rtree();
+
     // Disabling this test - there are no external inputs here,
     // so we disable range checking for performance.
     // BOOST_CHECK_THROW(db.getstring(id+1),std::out_of_range);

--- a/test/basic/extractor.cpp
+++ b/test/basic/extractor.cpp
@@ -28,8 +28,9 @@ BOOST_AUTO_TEST_CASE(annotator_test_basic)
                        "</way>\n"
                        "</osm>");
 
-    Database db;
+    Database db(true);
     Extractor extractor(buffer.c_str(), buffer.size(), "xml", db);
+    BOOST_CHECK(db.rtree);
 
     BOOST_CHECK_EQUAL(db.pair_way_map.size(), 4);
     BOOST_CHECK_EQUAL(db.external_internal_map.size(), 3);

--- a/test/basic/rtree.cpp
+++ b/test/basic/rtree.cpp
@@ -10,9 +10,10 @@ BOOST_AUTO_TEST_SUITE(rtree_test)
 // Verify that the bearing-bounds checking function behaves as expected
 BOOST_AUTO_TEST_CASE(rtree_basic_test)
 {
-    Database db;
+    Database db(true);
 
     db.used_nodes_list.emplace_back(point_t{1, 1}, 73);
+    db.build_rtree();
     db.compact();
     BOOST_CHECK_EQUAL(db.rtree->size(), 1);
 }
@@ -33,11 +34,12 @@ BOOST_AUTO_TEST_CASE(rtree_not_initialized)
 
 BOOST_AUTO_TEST_CASE(rtree_radius_test)
 {
-    Database db;
+    Database db(true);
 
     static const internal_nodeid_t TESTNODE{73};
 
     db.used_nodes_list.emplace_back(point_t{1, 1}, TESTNODE);
+    db.build_rtree();
     db.compact();
 
     RouteAnnotator annotator(db);
@@ -66,8 +68,9 @@ BOOST_AUTO_TEST_CASE(rtree_radius_test)
     BOOST_CHECK_EQUAL(results[0], TESTNODE);
 
     // Test at high latitudes
-    db = Database();
+    db = Database(true);
     db.used_nodes_list.emplace_back(point_t{1, 65}, TESTNODE);
+    db.build_rtree();
     db.compact();
 
     // This should be about 0.45m

--- a/test/load.test.js
+++ b/test/load.test.js
@@ -1,6 +1,6 @@
 var test = require('tape');
 const bindings = require('../index');
-const annotator = new bindings.Annotator();
+const annotator = new bindings.Annotator({ coordinates: true });
 const segmentmap = new bindings.SpeedLookup();
 const path = require('path');
 

--- a/test/load.test.js
+++ b/test/load.test.js
@@ -129,6 +129,36 @@ test('dont load CSV and see if you get the correct response (4 INVALID_SPEEDs)',
   });
 });
 
+test('annotator with invalid options object', function(t) {
+  try {
+    const coordsFalse = new bindings.Annotator(true);
+  }
+  catch(err) {
+    t.ok(err, 'returns error with non-object options')
+    t.end();
+  }
+});
+
+test('annotator with non-boolean coordinates options', function(t) {
+  try {
+    const coordsFalse = new bindings.Annotator({ coordinates: 1});
+  }
+  catch(err) {
+    t.ok(err, 'returns error with unrecognized annotator options');
+    t.end();
+  }
+});
+
+test('annotator with unrecognized options', function(t) {
+  try {
+    const coordsFalse = new bindings.Annotator({ coordinate: true });
+  }
+  catch(err) {
+    t.ok(err, 'returns error with unrecognized annotator options');
+    t.end();
+  }
+});
+
 test('annotator without coordinates support - by default', function(t) {
   const coordsFalse = new bindings.Annotator();
   coordsFalse.loadOSMExtract(path.join(__dirname,'data/winthrop.osm'), (err) => {
@@ -151,14 +181,4 @@ test('annotator without coordinates support - explicit', function(t) {
       t.end();
     });
   });
-});
-
-test.only('annotator with unrecognized options', function(t) {
-  try {
-    const coordsFalse = new bindings.Annotator({ coordinate: true });
-  }
-  catch(err) {
-    t.equals(err.toString().match('SyntaxError')[0], 'SyntaxError', 'returns error with unrecognized annotator options');
-    t.end();
-  }
 });

--- a/test/load.test.js
+++ b/test/load.test.js
@@ -135,7 +135,7 @@ test('annotator without coordinates support - by default', function(t) {
     if (err) throw err;
     var coords = [[-120.1872774,48.4715898],[-120.1882910,48.4725110]];
     coordsFalse.annotateRouteFromLonLats(coords, (err) => {
-      t.equals(err.toString(), 'Error: Annotator not created with coordinates support');
+      t.ok(err, 'returns error when annotator not built with coordinates support');
       t.end();
     });
   });
@@ -147,7 +147,7 @@ test('annotator without coordinates support - explicit', function(t) {
     if (err) throw err;
     var coords = [[-120.1872774,48.4715898],[-120.1882910,48.4725110]];
     coordsFalse.annotateRouteFromLonLats(coords, (err) => {
-      t.equals(err.toString(), 'Error: Annotator not created with coordinates support');
+      t.ok(err, 'returns error when annotator not built with coordinates support');
       t.end();
     });
   });

--- a/test/load.test.js
+++ b/test/load.test.js
@@ -128,3 +128,27 @@ test('dont load CSV and see if you get the correct response (4 INVALID_SPEEDs)',
     t.end();
   });
 });
+
+test('annotator without coordinates support - by default', function(t) {
+  const coordsFalse = new bindings.Annotator();
+  coordsFalse.loadOSMExtract(path.join(__dirname,'data/winthrop.osm'), (err) => {
+    if (err) throw err;
+    var coords = [[-120.1872774,48.4715898],[-120.1882910,48.4725110]];
+    coordsFalse.annotateRouteFromLonLats(coords, (err) => {
+      t.equals(err.toString(), 'Error: Annotator not created with coordinates support');
+      t.end();
+    });
+  });
+});
+
+test('annotator without coordinates support - explicit', function(t) {
+  const coordsFalse = new bindings.Annotator({ coordinates: false });
+  coordsFalse.loadOSMExtract(path.join(__dirname,'data/winthrop.osm'), (err) => {
+    if (err) throw err;
+    var coords = [[-120.1872774,48.4715898],[-120.1882910,48.4725110]];
+    coordsFalse.annotateRouteFromLonLats(coords, (err) => {
+      t.equals(err.toString(), 'Error: Annotator not created with coordinates support');
+      t.end();
+    });
+  });
+});

--- a/test/load.test.js
+++ b/test/load.test.js
@@ -152,3 +152,13 @@ test('annotator without coordinates support - explicit', function(t) {
     });
   });
 });
+
+test.only('annotator with unrecognized options', function(t) {
+  try {
+    const coordsFalse = new bindings.Annotator({ coordinate: true });
+  }
+  catch(err) {
+    t.equals(err.toString().match('SyntaxError')[0], 'SyntaxError', 'returns error with unrecognized annotator options');
+    t.end();
+  }
+});


### PR DESCRIPTION
Closes https://github.com/mapbox/route-annotator/issues/19

To do:
- [x] Put RTree generation into a separate method of `Database`, rather than part of `compact()`
- [x] Add checks into `annotateRouteFromLonLats()` for RTree exists, return null or error if it doesn't
- [x] Add tests
- [ ] Get review