### PR TITLE
Add builds for node 8 binaries.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,14 @@ matrix:
     - os: linux
       env: BUILDTYPE=debug
       node_js: 6
+    # linux publishable node v8
+    - os: linux
+      env: BUILDTYPE=release
+      node_js: 8
+    # linux publishable node v8/debug
+    - os: linux
+      env: BUILDTYPE=debug
+      node_js: 8
     # osx publishable node v4
     - os: osx
       osx_image: xcode8.2
@@ -69,6 +77,11 @@ matrix:
       osx_image: xcode8.2
       env: BUILDTYPE=release
       node_js: 6
+    # osx publishable node v8
+    - os: osx
+      osx_image: xcode8.2
+      env: BUILDTYPE=release
+      node_js: 8
     # Sanitizer build node v4/Debug
     - os: linux
       env: BUILDTYPE=debug TOOLSET=asan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Fixed code coverage environment and expanded test coverage
+- Add support for Node 8 pre-published binaries
 
 ## 0.1.0
 - Added filtering option based on a file of OSM tags


### PR DESCRIPTION
## Issue

This expands the Travis build matrix so that binaries for Node 8 will get published when a tag is made.
## Tasklist

- [ ] ~~Write code & tests~~
- [ ] Update relevant CHANGELOG and/or the README
- [ ] Get a review
- [ ] Rebase and clean up commits
- [ ] Merge & release (see README for release steps)

## Relevant parties and issues

Tag people, and other issues here.
