### PR TITLE
converting mph to kph - rounding was off

### DIFF
--- a/src/extractor.cpp
+++ b/src/extractor.cpp
@@ -203,7 +203,7 @@ void Extractor::way(const osmium::Way &way)
                         if (value.find("mph") != std::string::npos)
                         {
                             uint32_t speed = stoi(digits);
-                            std::uint32_t s = std::round(speed * 1.609);
+                            std::uint32_t s = std::round(speed * kKmPerMile);
                             digits = std::to_string(s);
                         }
                         const auto key_pos = db.addstring(tag.key());

--- a/src/segment_speed_map.cpp
+++ b/src/segment_speed_map.cpp
@@ -60,7 +60,7 @@ void SegmentSpeedMap::add_with_unit(const external_nodeid_t &from,
 {
     if (mph)
     {
-        std::uint32_t s = std::round(speed * 1.609);
+        std::uint32_t s = std::round(speed * kKmPerMile);
 
         if (s > INVALID_SPEED - 1)
         {

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -12,6 +12,8 @@ typedef std::uint32_t internal_nodeid_t;
 typedef std::uint32_t wayid_t;
 typedef std::uint8_t segment_speed_t;
 
+constexpr float kKmPerMile = 1.609344f;
+
 // Way ID, and whether it the node pair for it is stored forward or backward
 typedef struct
 {

--- a/src/way_speed_map.cpp
+++ b/src/way_speed_map.cpp
@@ -53,7 +53,7 @@ void WaySpeedMap::add(const wayid_t &way, const bool &mph, const std::uint32_t &
 
     if (mph)
     {
-        std::uint32_t s = std::round(speed * 1.609);
+        std::uint32_t s = std::round(speed * kKmPerMile);
 
         if (s > INVALID_SPEED - 1)
         {

--- a/test/tags-filter.test.js
+++ b/test/tags-filter.test.js
@@ -144,7 +144,7 @@ test('annotate by node on data filtered by tag', function(t) {
             annotator.getAllTagsForWayId(ids[0], (err, tags) => {
                 t.error(err, 'No error');
                 t.ok(tags.maxspeed, 'Has maxspeed tag');
-                t.equal(tags.maxspeed, '88', 'Got correct maxspeed');
+                t.equal(tags.maxspeed, '89', 'Got correct maxspeed');
                 t.equal(tags._way_id, '266323344', 'Got correct _way_id attribute on match');
             });
         });


### PR DESCRIPTION
Rounding was a bit off for converting from mph to kph.  For converting mph to kph multiple by 1.609344 vs 1.609  
