### PR TITLE
Enable builds for node 10, 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,22 @@ matrix:
     # linux publishable node v14/debug
     - os: linux
       env: BUILDTYPE=debug
+    # linux publishable node v12
+    - os: linux
+      env: BUILDTYPE=release
+      node_js: 12
+    # linux publishable node v12/debug
+    - os: linux
+      env: BUILDTYPE=debug
+      node_js: 12
+    # linux publishable node v10
+    - os: linux
+      env: BUILDTYPE=release
+      node_js: 10
+    # linux publishable node v10/debug
+    - os: linux
+      env: BUILDTYPE=debug
+      node_js: 10
     # osx publishable node v14
     - os: osx
       osx_image: xcode12


### PR DESCRIPTION
## Issue

Accidentally removed builds for node 10, 12.

For cases where you want to use this thing inside AWS Lambda, Node 12 support is required.

## Tasklist

- [ ] Write code & tests
- [ ] Update relevant CHANGELOG and/or the README
- [ ] Get a review
- [ ] Rebase and clean up commits
- [ ] Merge & release (see README for release steps)

## Relevant parties and issues

Tag people, and other issues here.
